### PR TITLE
Feat/dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 bin/
 package-lock.json
+yarn.lock
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 package-lock.json
 yarn.lock
 .DS_Store
+item.zip

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This repo contains the code to create the Zesty Banner smart item for use in Decentraland.
 
 To add a Zesty Banner into your DCL scene, download the latest release and import it into the DCL builder.
+
+## Quickstart
+1. Install the decentraland sdk. [See installation guide](https://docs.decentraland.org/development-guide/installation-guide/)
+
+2. Run `yarn` or `npm install`
+
+3. To start the scene run `dcl start`
+
+4. To build the asset pack run `dcl pack`

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repo contains the code to create the Zesty Banner smart item for use in Decentraland.
 
-To add a Zesty Banner into your DCL scene, download the latest [release](https://github.com/zestymarket/dcl/releases/tag/v1.0) and import it into the DCL builder.
+To add a Zesty Banner into your DCL scene, download the latest release and import it into the DCL builder.

--- a/asset.json
+++ b/asset.json
@@ -68,7 +68,7 @@
     },
     {
       "id": "beacon",
-      "label": "Beacon",
+      "label": "Beacon (Activate For Analytics)",
       "type": "boolean",
       "default": true
     }

--- a/asset.json
+++ b/asset.json
@@ -7,8 +7,18 @@
     {
       "id": "network",
       "label": "Network",
-      "type": "text",
-      "default": "Polygon"
+      "type": "options",
+      "options": [
+        {
+          "value": "polygon",
+          "label": "Polygon Mainnet"
+        },
+        {
+          "value": "rinkeby",
+          "label": "Rinkeby Testnet"
+        }
+      ],
+      "default": "polygon"
     },
     {
       "id": "space",
@@ -19,20 +29,48 @@
     {
       "id": "format",
       "label": "Format",
-      "type": "text",
+      "type": "options",
+      "options": [
+        {
+          "value": "square",
+          "label": "Square (1:1)"
+        },
+        {
+          "value": "tall",
+          "label": "Tall (3:4)"
+        },
+        {
+          "value": "wide",
+          "label": "Wide (4:1)"
+        }
+      ],
       "default": "square"
     },
     {
       "id": "style",
       "label": "Style",
-      "type": "text",
-      "default": "Standard"
+      "type": "options",
+      "options": [
+        {
+          "value": "standard",
+          "label": "Standard"
+        },
+        {
+          "value": "minimal",
+          "label": "Minimal"
+        },
+        {
+          "value": "transparent",
+          "label": "Transparent"
+        }
+      ],
+      "default": "standard"
     },
     {
       "id": "beacon",
       "label": "Beacon",
       "type": "boolean",
-      "default": false
+      "default": true
     }
   ],
   "actions": []

--- a/asset.json
+++ b/asset.json
@@ -68,7 +68,7 @@
     },
     {
       "id": "beacon",
-      "label": "Beacon (Activate For Analytics)",
+      "label": "Beacon (For Analytics)",
       "type": "boolean",
       "default": true
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zesty-dcl-banners",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Zesty Banner smart item for use in Decentraland.",
   "scripts": {
     "start": "dcl start",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Zesty DCL Banners",
+  "name": "zesty-dcl-banners",
   "version": "1.0.0",
   "description": "A Zesty Banner smart item for use in Decentraland.",
   "scripts": {

--- a/src/game.ts
+++ b/src/game.ts
@@ -15,6 +15,6 @@ spawner.spawn(
     space: "999999",
     format: "square",
     style: "transparent",
-    beacon: false
+    beacon: true
   }
 )


### PR DESCRIPTION
Changes
1. Added dropdowns
2. More details in labels to explain the ratios of 'tall', 'square', 'wide'
3. More details regarding beacons
4. Made beacons true by default. Beacons should be opt-out by default. See https://gov.zesty.market/t/data-sdk-proposal-1-make-beacons-opt-out-rather-than-opt-in-by-default/18/3
5. Bump minor version to `1.1.0`